### PR TITLE
use new name for dns zone module

### DIFF
--- a/examples/zone-records/README.md
+++ b/examples/zone-records/README.md
@@ -28,7 +28,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_dns_zone"></a> [dns\_zone](#module\_dns\_zone) | git::https://github.com/nexient-llc/tf-aws-collection_module-dns_zone.git | 0.1.2 |
+| <a name="module_dns_zone"></a> [dns\_zone](#module\_dns\_zone) | git::https://github.com/nexient-llc/tf-aws-module_primitive-dns_zone.git | 0.1.2 |
 | <a name="module_dns_record"></a> [dns\_record](#module\_dns\_record) | ../.. | n/a |
 
 ## Resources

--- a/examples/zone-records/main.tf
+++ b/examples/zone-records/main.tf
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 module "dns_zone" {
-  source = "git::https://github.com/nexient-llc/tf-aws-collection_module-dns_zone.git?ref=0.1.2"
+  source = "git::https://github.com/nexient-llc/tf-aws-module_primitive-dns_zone.git?ref=0.1.2"
 
   zones  = var.zones
   create = var.create


### PR DESCRIPTION
The migration script fails on this repo when it translates the dns zone module dependency to point at the new org, since there is no redirect there.